### PR TITLE
fix: redraw after toggling on `CmdlineEnter` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ After installed, this plugin will automatically active so no setup statement is 
 require("relative-toggle").setup ({
     pattern = "*",
     events = {
-        on = { "BufEnter", "FocusGained", "InsertLeave", "WinEnter", "CmdLineLeave" },
-        off = { "BufLeave", "FocusLost", "InsertEnter", "WinLeave", "CmdLineEnter" },
+        on = { "BufEnter", "FocusGained", "InsertLeave", "WinEnter", "CmdlineLeave" },
+        off = { "BufLeave", "FocusLost", "InsertEnter", "WinLeave", "CmdlineEnter" },
     },
 })
 ```

--- a/lua/relative-toggle/config.lua
+++ b/lua/relative-toggle/config.lua
@@ -10,8 +10,8 @@ config.options = {
     ---• `off`: event to turn relative number off
     ---see: [autocmd-events]
     events = {
-        on = { "BufEnter", "FocusGained", "InsertLeave", "WinEnter", "CmdLineLeave" },
-        off = { "BufLeave", "FocusLost", "InsertEnter", "WinLeave", "CmdLineEnter" },
+        on = { "BufEnter", "FocusGained", "InsertLeave", "WinEnter", "CmdlineLeave" },
+        off = { "BufLeave", "FocusLost", "InsertEnter", "WinLeave", "CmdlineEnter" },
     },
 }
 

--- a/lua/relative-toggle/init.lua
+++ b/lua/relative-toggle/init.lua
@@ -21,8 +21,9 @@ local function set_relativenumber(relative, redraw)
 
     if vim.o.number then
         vim.opt.relativenumber = relative and not in_insert_mode
+
         if redraw then
-            vim.cmd("redraw")
+            vim.cmd "redraw"
         end
     end
 end

--- a/lua/relative-toggle/init.lua
+++ b/lua/relative-toggle/init.lua
@@ -15,11 +15,15 @@ local function create_autocmd(event, opts)
 end
 
 ---@param relative boolean #whether relativenumber should be set
-local function set_relativenumber(relative)
+---@param redraw boolean #whether to redraw the screen
+local function set_relativenumber(relative, redraw)
     local in_insert_mode = vim.api.nvim_get_mode().mode == "i"
 
     if vim.o.number then
         vim.opt.relativenumber = relative and not in_insert_mode
+        if redraw then
+            vim.cmd("redraw")
+        end
     end
 end
 
@@ -34,8 +38,8 @@ function M.setup(user_config)
         pattern = config.pattern,
         group = augroup,
         desc = "turn relative number on",
-        callback = function()
-            set_relativenumber(true)
+        callback = function(ev)
+            set_relativenumber(true, ev.event == "CmdlineEnter")
         end,
     })
 
@@ -43,8 +47,8 @@ function M.setup(user_config)
         pattern = config.pattern,
         group = augroup,
         desc = "turn relative number off",
-        callback = function()
-            set_relativenumber(false)
+        callback = function(ev)
+            set_relativenumber(false, ev.event == "CmdlineEnter")
         end,
     })
 end


### PR DESCRIPTION
Redraw the screen after toggling on the CmdlineEnter event, otherwise the change does not appear to take effect for this event only.

Credit to https://vi.stackexchange.com/a/31218