### PR TITLE
fix: keep the combination of `number` and `relativenumber`

### DIFF
--- a/lua/relative-toggle/init.lua
+++ b/lua/relative-toggle/init.lua
@@ -14,17 +14,19 @@ local function create_autocmd(event, opts)
     end
 end
 
+-- to keep the combination of relativenumber and number
+local current_number = vim.o.number
+
 ---@param relative boolean #whether relativenumber should be set
 ---@param redraw boolean #whether to redraw the screen
 local function set_relativenumber(relative, redraw)
     local in_insert_mode = vim.api.nvim_get_mode().mode == "i"
 
-    if vim.o.number then
-        vim.opt.relativenumber = relative and not in_insert_mode
+    vim.opt.number = not relative or current_number
+    vim.opt.relativenumber = relative and not in_insert_mode
 
-        if redraw then
-            vim.cmd "redraw"
-        end
+    if redraw then
+        vim.cmd "redraw"
     end
 end
 


### PR DESCRIPTION
Resolved #7 

1. `number` is not set

![number](https://user-images.githubusercontent.com/42694704/226103655-daebf569-18bc-4412-b5df-d73fda310925.mov)

2. `number` is set
 
![nonumber](https://user-images.githubusercontent.com/42694704/226104420-6194e9c6-3f6a-4358-9f61-ee80d9cc71bb.mov)

