### PR TITLE
Revert "fix: keep the combination of `number` and `relativenumber` (#8)"

### DIFF
--- a/lua/relative-toggle/init.lua
+++ b/lua/relative-toggle/init.lua
@@ -14,19 +14,17 @@ local function create_autocmd(event, opts)
     end
 end
 
--- to keep the combination of relativenumber and number
-local current_number = vim.o.number
-
 ---@param relative boolean #whether relativenumber should be set
 ---@param redraw boolean #whether to redraw the screen
 local function set_relativenumber(relative, redraw)
     local in_insert_mode = vim.api.nvim_get_mode().mode == "i"
 
-    vim.opt.number = not relative or current_number
-    vim.opt.relativenumber = relative and not in_insert_mode
+    if vim.o.number then
+        vim.opt.relativenumber = relative and not in_insert_mode
 
-    if redraw then
-        vim.cmd "redraw"
+        if redraw then
+            vim.cmd "redraw"
+        end
     end
 end
 


### PR DESCRIPTION
This reverts commit 8e3837f1bfe24e71f855352da6d4541264bf3099 which causes an unexpected bug in some of places